### PR TITLE
Enhance resource list support with fzf

### DIFF
--- a/autoload/replant/ui.vim
+++ b/autoload/replant/ui.vim
@@ -59,6 +59,13 @@ fun! replant#ui#quickfix_resources_list()
   let send = replant#generate#resource_list()
   let msgs = replant#send#message(send)
   let qfs = replant#handle#quickfix_resources_list(msgs)
+
+  if exists("*fzf#run")
+    let resources = map(qfs, 'v:val.filename')
+    call fzf#run(fzf#wrap(fzf#vim#with_preview({'source': resources}, 'right:hidden', '?')))
+    return
+  endif
+
   call setqflist(qfs)
   copen
 endf


### PR DESCRIPTION
This commit adds functionality to use fzf (if it is installed) as the default output for the resource list, it is a good first pass at #7 that may be expanded on in the future. The defaults for fzf preview (right side/toggle with `?`) make sense for me but could be customised at some point. Making use of `fzf#wrap` means we get a lot of functionality for nothing as it decorates the fzf options with many useful defaults.

Fix #7 