### PR TITLE
Handle case when fzf is installed, but fzf.vim is not

### DIFF
--- a/autoload/replant/ui.vim
+++ b/autoload/replant/ui.vim
@@ -60,7 +60,7 @@ fun! replant#ui#quickfix_resources_list()
   let msgs = replant#send#message(send)
   let qfs = replant#handle#quickfix_resources_list(msgs)
 
-  if exists("*fzf#run")
+  if exists("*fzf#vim#with_preview")
     let resources = map(qfs, 'v:val.filename')
     call fzf#run(fzf#wrap(fzf#vim#with_preview({'source': resources}, 'right:hidden', '?')))
     return


### PR DESCRIPTION
When you have [`fzf`](https://github.com/junegunn/fzf) installed, but
not [`fzf.vim`](https://github.com/junegunn/fzf) there are a limited set
of fzf commands available (`fzf#run`,`fzf#shellescape`,`fzf#wrap`) This
causes `:ReplantListResources` to break

```
Error detected while processing function replant#ui#quickfix_resources_list:
line    7:
E117: Unknown function: fzf#vim#with_preview
E116: Invalid arguments for function fzf#wrap
E116: Invalid arguments for function fzf#run
```