### PR TITLE
Enhance find symbol with fzf

### DIFF
--- a/autoload/replant/handle.vim
+++ b/autoload/replant/handle.vim
@@ -14,8 +14,7 @@ fun! replant#handle#quickfix_find_symbol(msgs)
       return 0
     endif
   endfor
-
-  call setqflist(qfs)
+  return qfs
 endf
 
 fun! replant#handle#hotload(cmsg)


### PR DESCRIPTION
This commit adds functionality to use fzf (if it is installed) as the default output for find symbol. Ideally I would like to use some built in default sink function in fzf instead of creating one for replant, but perhaps as replant grows this might not be a bad idea. The sink function I have created is much like the sink function used for Ag in fzf (https://github.com/junegunn/fzf.vim/blob/3661409e952b8532a2088226de886aea0489e281/autoload/fzf/vim.vim#L612-L649).

If there is a preference not to create a sink function like this, or not to include it in `ui.vim` then let me know and I will change it.