### PR TITLE
Support rerunning failed tests

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -100,6 +100,11 @@ You can run project tests with `:ReplantTestProject`, which takes these argument
 
 You can conveniently run tests with `<localleader>rtp` too.
 
+It is also possible to rerun only previously failed tests using `ReplantRetestProject`, which takes these arguments:
+
+`-load`:: Automatically load project namespaces if they are unloaded (default)
+`-no-load`:: Do not automatically load project namespaces
+
 Sometimes tests throw an exception, you can use the full power of the tagged stacktrace explorer with tests.
 A command will be conveniently provided to you in the form `:ReplantTestStacktrace ns var nr`.
 You *must switch to a clojure buffer to run this*.

--- a/autoload/replant/generate.vim
+++ b/autoload/replant/generate.vim
@@ -62,6 +62,18 @@ fun! replant#generate#test_project(args)
   return msg
 endf
 
+fun! replant#generate#retest_project(args)
+  let opts = a:args
+
+  if get(a:args, 'load?')
+    let opts['load?'] = 1
+  endif
+
+  let msg = extend({'op': 'retest'}, opts)
+
+  return msg
+endf
+
 fun! replant#generate#test_results_info(msgs)
   " TODO: Refactor the find_test_result_msg out
   let result_msg = replant#handle#find_test_results_msg(a:msgs)

--- a/autoload/replant/ui.vim
+++ b/autoload/replant/ui.vim
@@ -133,21 +133,8 @@ fun! replant#ui#last_stacktrace()
   lopen
 endf
 
-fun! replant#ui#test_project(...)
-  let opts = {'load?': 1}
-
-  for x in a:000
-    if x ==# '-no-load'
-      let opts['load?'] = 0
-    elseif x ==# '-load'
-      let opts['load?'] = 1
-    elseif x =~# '^-selector='
-      let opts['selector'] = matchstr(x, '-selector=\zs.*')
-    endif
-  endfor
-
-  let send = replant#generate#test_project(opts)
-  let msgs = replant#send#message(send)
+fun! replant#ui#handle_test(msg)
+  let msgs = replant#send#message(a:msg)
 
   let info_ops = replant#generate#test_results_info(msgs)
 
@@ -170,6 +157,36 @@ fun! replant#ui#test_project(...)
   endif
 
   call replant#handle#test_summary(msgs)
+endf
+
+fun! replant#ui#test_project(...)
+  let opts = {'load?': 1}
+
+  for x in a:000
+    if x ==# '-no-load'
+      let opts['load?'] = 0
+    elseif x ==# '-load'
+      let opts['load?'] = 1
+    elseif x =~# '^-selector='
+      let opts['selector'] = matchstr(x, '-selector=\zs.*')
+    endif
+  endfor
+
+  call replant#ui#handle_test(replant#generate#test_project(opts))
+endf
+
+fun! replant#ui#retest_project(...)
+  let opts = {'load?': 1}
+
+  for x in a:000
+    if x ==# '-no-load'
+      let opts['load?'] = 0
+    elseif x ==# '-load'
+      let opts['load?'] = 1
+    endif
+  endfor
+
+  call replant#ui#handle_test(replant#generate#retest_project(opts))
 endf
 
 fun! replant#ui#test_stacktrace(ns, var, index)

--- a/ftplugin/clojure.vim
+++ b/ftplugin/clojure.vim
@@ -35,5 +35,6 @@ command! -buffer -nargs=0 ReplantListResources call replant#ui#quickfix_resource
 command! -buffer -nargs=0 ReplantLastStacktrace call replant#ui#last_stacktrace()
 
 command! -buffer -nargs=* ReplantTestProject call replant#ui#test_project(<f-args>)
+command! -buffer -nargs=* ReplantRetestProject call replant#ui#retest_project(<f-args>)
 nnoremap <silent><buffer> <localleader>rtp :<C-U>call replant#ui#test_project()<CR>
 command! -buffer -nargs=+ ReplantTestStacktrace call replant#ui#test_stacktrace(<f-args>)


### PR DESCRIPTION
I've added support for running previously failed tests using the cider `retest` op, exposed as `ReplantRetestProject`. 

I have left the `-load` and `-no-load` options as per `ReplantTestProject` but have removed the `-selector` option, I can add if it required but it was logical to me that when running only previously failed tests you almost certainly wouldn't want to narrow those down with a selector. It might be that `-load` and `-no-load`also don't make sense in the "rerun failed tests" scenario but I'm not sure about that. 