### PR TITLE
Enable docstring preview for ReplantApropos

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -125,10 +125,6 @@ NOTE: Special symbols, recognizable by their lack of namespace, do not have a so
 
 WARNING: The doc information is not well tested, and is highly subject to change.
 
-You can control whether doc strings are shown alongside vars by setting `g:replant_apropos_doc` to `1`.
-
-WARNING: I may remove this global flag and change how this is controlled.
-
 == Developing
 
 I use link:https://squiddev.github.io/urn/[urn] to generate lua files from lisp.

--- a/autoload/replant/generate.vim
+++ b/autoload/replant/generate.vim
@@ -92,7 +92,7 @@ fun! replant#generate#test_stacktrace(ns,var,index)
 endf
 
 fun! replant#generate#apropos_var_query(var_query)
-  return {'op': 'apropos', 'ns': fireplace#ns(), 'var-query': a:var_query}
+  return {'op': 'apropos', 'ns': fireplace#ns(), 'var-query': a:var_query, 'full-doc?': 1}
 endf
 
 fun! replant#generate#jump_to_source_full_symbol(full_symbol)

--- a/autoload/replant/handle.vim
+++ b/autoload/replant/handle.vim
@@ -220,7 +220,11 @@ fun! replant#handle#apropos_fzf(msgs)
   let result = a:msgs[0]
   let apropos_matches = get(result, 'apropos-matches', [])
 
-  let resources = map(apropos_matches, {idx, x -> x['name'].':'.x['doc']})
+  let resources = []
+  
+  for m in apropos_matches 
+    let resources += [m['name'].':', '', '  '.m['doc']]
+  endfor
 
   let actions = {'ctrl-x': ['jump', 'split'],
                \ 'ctrl-v': ['jump', 'vertical split'],
@@ -231,9 +235,9 @@ fun! replant#handle#apropos_fzf(msgs)
   let Resolver = {a -> get(actions, a, ['jump', 'edit'])}
 
   let file = tempname()
-  let preview_command = 'grep -ae {}: '.file.' | cut -d : -f 2-9999 | xargs --null printf "%s\n" | sed -e "s/^[[:space:]]*//"'
+  let preview_command = 'grep -a -A 2 {}: '.file.' | xargs --null printf "%s\n"'
   call writefile(resources, file)
-  let opts = {'source': map(resources, {idx, x -> split(x, ":")[0]}),
+  let opts = {'source': map(apropos_matches, {idx, x -> x['name']}),
             \ 'sink*': function('replant#fzf#symbol_jump', [Resolver]),
             \ 'options': "--expect=ctrl-t,ctrl-v,ctrl-x,ctrl-i,ctrl-y --multi --tiebreak=index --color --preview-window wrap --preview '".preview_command."'"}
   call fzf#run(fzf#wrap(opts))


### PR DESCRIPTION
This commit enables an inline docstring preview using the preview functionality provided by fzf, it does so by writing a temp file made up of the var and docstring as provided by apropos, the fzf preview command is then set to a shell command that greps the temp file and does some munging to produce a readable docstring.

It is likely that this shell command could be improved as I am not great with bash, one point of discussion might be the field range passed to `cut`, is there a more elegant way of cutting and taking all fields from index 2 to end? I want to write something like `cut -d : -f 2-*` but that is not valid, so for now I have used an arbitrary high number. Another point of dicussion might be how portable the shell command is.

Example of functionality:

![ReplantApropos](https://i.imgur.com/xDVHYK4.gif)
